### PR TITLE
Fix style path for CockroachDB

### DIFF
--- a/website/docs/vale/about.mdx
+++ b/website/docs/vale/about.mdx
@@ -51,7 +51,7 @@ organizations, and open-source projects around the world:
 |     `linode/docs`     |                 [`.vale.ini`](https://github.com/linode/docs/blob/develop/.vale.ini), [`StylesPath`](https://github.com/linode/docs/tree/develop/ci/vale)                 |
 |    `Homebrew/brew`    |       [`.vale.ini`](https://github.com/Homebrew/brew/blob/master/.vale.ini), [`StylesPath`](https://github.com/Homebrew/brew/tree/master/docs/vale-styles/Homebrew)       |
 |  `spotify/backstage`  |        [`.vale.ini`](https://github.com/spotify/backstage/blob/master/.vale.ini), [`StylesPath`](https://github.com/spotify/backstage/tree/master/.github/styles)         |
-|  `cockroachdb/docs`   |             [`.vale.ini`](https://github.com/cockroachdb/docs/blob/master/.vale.ini), [`StylesPath`](https://github.com/cockroachdb/docs/tree/master/ci/vale)             |
+|  `cockroachdb/docs`   |             [`.vale.ini`](https://github.com/cockroachdb/docs/blob/master/.vale.ini), [`StylesPath`](https://github.com/cockroachdb/docs/tree/master/netlify/vale)             |
 |    `github/codeql`    |  [`.vale.ini`](https://github.com/github/codeql/blob/main/docs/codeql/.vale.ini), [`StylesPath`](https://github.com/github/codeql/tree/main/docs/codeql/vale-styles)  |
 | `netlify/netlify-cms` | [`.vale.ini`](https://github.com/netlify/netlify-cms/blob/master/.vale.ini), [`StylesPath`](https://github.com/netlify/netlify-cms/tree/master/website/src/writing-guide) |
 


### PR DESCRIPTION
Currently style path link for Cockroach DB is broken. With this PR, the URL points to the updated path.